### PR TITLE
Removing igortg from the maintainers list

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -369,6 +369,5 @@ extra:
   feedstock-name: sqlalchemy-utils
   recipe-maintainers:
     - lvoliveira
-    - igortg
     - xmnlab
     - bollwyvl


### PR DESCRIPTION
I'm trying to reduce the list of packages I'm a maintainer.